### PR TITLE
Simplify `Sync::Lockable` interface (internal refactor)

### DIFF
--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -118,32 +118,8 @@ module Sync
     def unsafe_set(@value : T) : T
     end
 
-    protected def type : Type
-      lock.type
-    end
-
-    protected def locked_by? : Fiber?
-      lock.locked_by?
-    end
-
-    protected def locked_by=(locked_by : Fiber?) : Fiber?
-      lock.locked_by = locked_by
-    end
-
-    protected def counter : Int32
-      lock.counter
-    end
-
-    protected def counter=(counter : Int32)
-      lock.counter = counter
-    end
-
-    protected def owns_lock? : Bool
-      lock.owns_lock?
-    end
-
-    protected def mu : Pointer(MU)
-      lock.mu
+    protected def wait(cv : Pointer(CV)) : Nil
+      lock.wait(cv)
     end
   end
 end

--- a/src/lockable.cr
+++ b/src/lockable.cr
@@ -18,12 +18,6 @@ module Sync
       Reentrant
     end
 
-    protected abstract def type : Type
-    protected abstract def locked_by? : Fiber?
-    protected abstract def locked_by=(locked_by : Fiber?) # : Fiber?
-    protected abstract def counter : Int32
-    protected abstract def counter=(counter : Int32) # : Int32
-    protected abstract def owns_lock? : Bool
-    protected abstract def mu : Pointer(MU)
+    protected abstract def wait(cv : Pointer(CV)) : Nil
   end
 end

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -129,32 +129,8 @@ module Sync
     def unsafe_set(@value : T) : T
     end
 
-    protected def type : Type
-      lock.type
-    end
-
-    protected def locked_by? : Fiber?
-      lock.locked_by?
-    end
-
-    protected def locked_by=(locked_by : Fiber?) : Fiber?
-      lock.locked_by = locked_by
-    end
-
-    protected def counter : Int32
-      lock.counter
-    end
-
-    protected def counter=(counter : Int32)
-      lock.counter = counter
-    end
-
-    protected def owns_lock? : Bool
-      lock.owns_lock?
-    end
-
-    protected def mu : Pointer(MU)
-      lock.mu
+    protected def wait(cv : Pointer(CV)) : Nil
+      lock.wait(cv)
     end
   end
 end


### PR DESCRIPTION
We can hide all the check details under a single `Sync::Lockable#wait(CV*)` method, so all the check details belong to `Sync::Mutex` and `Sync::RWLock`.

Note: it can't be an `#unsynchronized(&)` method because `Sync::CV#wait(MU*)` will do the actual unlock. We only need the Mutex/RWLock to do the pre-unlock and after-lock checks.