### PR TITLE
Rework interface of `Sync::Shared` and `Sync::Exclusive`

### DIFF
--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -67,13 +67,13 @@ module Sync
 
     # Locks the mutex and returns a shallow copy of the value. The lock is
     # released before returning the new value.
-    def dup : T
+    def dup_value : T
       lock.synchronize { @value.dup }
     end
 
     # Locks the mutex and returns a deep copy of the value. The lock is
     # released before returning the new value.
-    def clone : T
+    def clone_value : T
       lock.synchronize { @value.clone }
     end
 
@@ -83,8 +83,8 @@ module Sync
     # with the other methods. However, safely accessing the returned value
     # entirely depends on the safety of `T`, which should be `Sync::Safe`.
     #
-    # Prefer `#dup` or `#clone` to get a shallow or deep copy of the value
-    # instead.
+    # Prefer `#dup_value` or `#clone_value` to get a shallow or deep copy of the
+    # value instead.
     #
     # WARNING: Breaks the mutual exclusion guarantee, since the returned value
     # outlives the lock it can be accessed in parallel to the synchronized

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -77,7 +77,7 @@ module Sync
       lock.synchronize { @value.clone }
     end
 
-    # Locks the mutex and returns the value. Unlocks the mutex before returning.
+    # Locks the mutex and returns the value. Unlocks before returning.
     #
     # Always acquires the lock, so reading the value is synchronized in relation
     # with the other methods. However, safely accessing the returned value
@@ -89,7 +89,7 @@ module Sync
     # WARNING: Breaks the mutual exclusion guarantee, since the returned value
     # outlives the lock it can be accessed in parallel to the synchronized
     # methods.
-    def get : T
+    def value : T
       lock.synchronize { @value }
     end
 

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -97,7 +97,7 @@ module Sync
     #
     # Always acquires and releases the lock, so writing the value is always
     # synchronized with the other methods.
-    def set(value : T) : T forall T
+    def set(value : T) : Nil
       lock.synchronize { @value = value }
     end
 

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -56,12 +56,12 @@ module Sync
     # Locks the mutex, yields the value and eventually replaces the value with
     # the one returned by the block. The lock is released before returning.
     #
-    # The yielded value is owned: it can be safely mutated and even retained
+    # The current value is now owned: it can be safely retained and mutated even
     # after the block returned.
     #
     # WARNING: The new value musn't be retained and accessed after the block has
     # returned.
-    def replace(& : T -> T) : T
+    def replace(& : T -> T) : Nil
       lock.synchronize { @value = yield @value }
     end
 

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -104,7 +104,7 @@ module Sync
     # WARNING: Breaks the shared/exclusive guarantees, since the returned value
     # outlives the lock; it can be accessed in parallel to the synchronized
     # methods.
-    def get : T
+    def value : T
       lock.read { @value }
     end
 

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -71,11 +71,12 @@ module Sync
     # the value with the one returned by the block. The lock is released before
     # returning.
     #
-    # The current value is owned: it can be safely mutated and even retained
+    # The current value is now owned: it can be safely retained and mutated even
     # after the block returned.
     #
-    # WARNING: The new value musn't be accessed after the block has returned.
-    def replace(& : T -> T) : T
+    # WARNING: The new value musn't be retained and accessed after the block has
+    # returned.
+    def replace(& : T -> T) : Nil
       lock.write { @value = yield @value }
     end
 
@@ -91,7 +92,7 @@ module Sync
       lock.read { @value.clone }
     end
 
-    # Locks in shared mode and returns the value.
+    # Locks in shared mode and returns the value. Unlocks before returning.
     #
     # Always acquires the lock, so reading the value is synchronized in relation
     # with the other methods. However, safely accessing the returned value

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -82,13 +82,13 @@ module Sync
 
     # Locks in shared mode and returns a shallow copy of the value. The lock is
     # released before returning the new value.
-    def dup : T
+    def dup_value : T
       lock.read { @value.dup }
     end
 
     # Locks in shared mode and returns a deep copy of the value. The lock is
     # released before returning the new value.
-    def clone : T
+    def clone_value : T
       lock.read { @value.clone }
     end
 
@@ -98,8 +98,8 @@ module Sync
     # with the other methods. However, safely accessing the returned value
     # entirely depends on the safety of `T`, which should be `Sync::Safe`.
     #
-    # Prefer `#dup` or `#clone` to get a shallow or deep copy of the value
-    # instead.
+    # Prefer `#dup_value` or `#clone_value` to get a shallow or deep copy of the
+    # value instead.
     #
     # WARNING: Breaks the shared/exclusive guarantees, since the returned value
     # outlives the lock; it can be accessed in parallel to the synchronized

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -109,7 +109,7 @@ module Sync
     end
 
     # Locks in exclusive mode and sets the value.
-    def set(value : T) : T
+    def set(value : T) : Nil
       lock.write { @value = value }
     end
 

--- a/test/exclusive_test.cr
+++ b/test/exclusive_test.cr
@@ -35,21 +35,21 @@ describe Sync::Exclusive do
     assert_same ary2, var.get
   end
 
-  it "#dup" do
+  it "#dup_value" do
     ary = [[1, 2, 3, 4, 5]]
     var = Sync::Exclusive.new(ary)
 
-    copy = var.dup
+    copy = var.dup_value
     refute_same ary, copy
     assert_same ary[0], copy[0]
     assert_equal ary, copy
   end
 
-  it "#clone" do
+  it "#clone_value" do
     ary = [[1, 2, 3, 4, 5]]
     var = Sync::Exclusive.new(ary)
 
-    copy = var.clone
+    copy = var.clone_value
     refute_same ary, copy
     refute_same ary[0], copy[0]
     assert_equal ary, copy
@@ -116,9 +116,9 @@ describe Sync::Exclusive do
       wg.spawn(name: "dup-clone") do
         100.times do |i|
           if i % 2 == 0
-            var.dup
+            var.dup_value
           else
-            var.clone
+            var.clone_value
           end
           Fiber.yield
         end

--- a/test/exclusive_test.cr
+++ b/test/exclusive_test.cr
@@ -11,7 +11,7 @@ describe Sync::Exclusive do
   it "#get" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Exclusive.new(ary)
-    assert_same ary, var.get
+    assert_same ary, var.value
   end
 
   it "#set" do
@@ -20,7 +20,7 @@ describe Sync::Exclusive do
 
     var = Sync::Exclusive.new(ary1)
     var.set(ary2)
-    assert_same ary2, var.get
+    assert_same ary2, var.value
   end
 
   it "#replace" do
@@ -32,7 +32,7 @@ describe Sync::Exclusive do
       assert_same ary1, value
       ary2
     end
-    assert_same ary2, var.get
+    assert_same ary2, var.value
   end
 
   it "#dup_value" do

--- a/test/shared_test.cr
+++ b/test/shared_test.cr
@@ -43,21 +43,21 @@ describe Sync::Shared do
     assert_same ary2, var.get
   end
 
-  it "#dup" do
+  it "#dup_value" do
     ary = [[1, 2, 3, 4, 5]]
     var = Sync::Shared.new(ary)
 
-    copy = var.dup
+    copy = var.dup_value
     refute_same ary, copy
     assert_same ary[0], copy[0]
     assert_equal ary, copy
   end
 
-  it "#clone" do
+  it "#clone_value" do
     ary = [[1, 2, 3, 4, 5]]
     var = Sync::Shared.new(ary)
 
-    copy = var.clone
+    copy = var.clone_value
     refute_same ary, copy
     refute_same ary[0], copy[0]
     assert_equal ary, copy
@@ -124,9 +124,9 @@ describe Sync::Shared do
       wg.spawn(name: "dup-clone") do
         100.times do |i|
           if i % 2 == 0
-            var.dup
+            var.dup_value
           else
-            var.clone
+            var.clone_value
           end
           Fiber.yield
         end

--- a/test/shared_test.cr
+++ b/test/shared_test.cr
@@ -12,14 +12,14 @@ describe Sync::Shared do
     ary1 = [1, 2, 3, 4, 5]
     var = Sync::Shared.new(ary1)
     var.write { |val| val << 6 }
-    assert_same ary1, var.get
+    assert_same ary1, var.value
     assert_equal [1, 2, 3, 4, 5, 6], ary1
   end
 
   it "#get" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Shared.new(ary)
-    assert_same ary, var.get
+    assert_same ary, var.value
   end
 
   it "#set" do
@@ -28,7 +28,7 @@ describe Sync::Shared do
 
     var = Sync::Shared.new(ary1)
     var.set(ary2)
-    assert_same ary2, var.get
+    assert_same ary2, var.value
   end
 
   it "#replace" do
@@ -40,7 +40,7 @@ describe Sync::Shared do
       assert_same ary1, value
       ary2
     end
-    assert_same ary2, var.get
+    assert_same ary2, var.value
   end
 
   it "#dup_value" do


### PR DESCRIPTION
The `#replace(&)` and `#set(T)` methods have no reason to return the new value.

The `#dup` and `#clone` methods can be confusing because they copy the underlying value, not the wrapper type, so they're renamed `#dup_value` and `#clone_value`.

The `#get : T` method that returns the value has been renamed `#value : T` to avoid a confusion with the `#get(&)` method that safely borrows the value for the duration of the block, and instead be closer to the new `#dup_value` and `#clone_value` methods. This is a first step to resolve #12.