### PR TITLE
Harmonize naming of yield methods of `Shared(T)` and `Exclusive(T)`

### DIFF
--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -57,6 +57,11 @@ module Sync
       lock.synchronize { yield @value }
     end
 
+    @[Deprecated("use #exclusive instead.")]
+    def get(& : T -> U) : U forall U
+      exclusive { |value| yield value }
+    end
+
     # Locks the mutex, yields the value and eventually replaces the value with
     # the one returned by the block. The lock is released before returning.
     #

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -14,15 +14,15 @@ module Sync
   #   @@running : Sync::Exclusive.new([] of Queue)
   #
   #   def self.on_started(queue)
-  #     @@running.get(&.push(queue))
+  #     @@running.exclusive(&.push(queue))
   #   end
   #
   #   def self.on_stopped(queue)
-  #     @@running.get(&.delete(queue))
+  #     @@running.exclusive(&.delete(queue))
   #   end
   #
   #   def self.each(&)
-  #     @@running.get do |list|
+  #     @@running.exclusive do |list|
   #       list.each { |queue| yield queue }
   #     end
   #   end

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -14,15 +14,15 @@ module Sync
   #   @@running : Sync::Exclusive.new([] of Queue)
   #
   #   def self.on_started(queue)
-  #     @@running.exclusive(&.push(queue))
+  #     @@running.lock(&.push(queue))
   #   end
   #
   #   def self.on_stopped(queue)
-  #     @@running.exclusive(&.delete(queue))
+  #     @@running.lock(&.delete(queue))
   #   end
   #
   #   def self.each(&)
-  #     @@running.exclusive do |list|
+  #     @@running.lock do |list|
   #       list.each { |queue| yield queue }
   #     end
   #   end
@@ -53,13 +53,13 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def exclusive(& : T -> U) : U forall U
+    def lock(& : T -> U) : U forall U
       lock.synchronize { yield @value }
     end
 
-    @[Deprecated("Use #exclusive instead.")]
+    @[Deprecated("Use #lock instead.")]
     def get(& : T -> U) : U forall U
-      exclusive { |value| yield value }
+      lock { |value| yield value }
     end
 
     # Locks the mutex, yields the value and eventually replaces the value with
@@ -82,7 +82,7 @@ module Sync
     # the lock early, instead of keeping the lock acquired for a while,
     # preventing progress of other fibers.
     #
-    # @[Experimental("The method may not have much value over #exclusive(&.dup)")]
+    # @[Experimental("The method may not have much value over #lock(&.dup)")]
     def dup_value : T
       lock.synchronize { @value.dup }
     end
@@ -90,7 +90,7 @@ module Sync
     # Locks the mutex and returns a deep copy of the value. The lock is
     # released before returning the new value.
     #
-    # @[Experimental("The method may not have much value over #exclusive(&.clone)")]
+    # @[Experimental("The method may not have much value over #lock(&.clone)")]
     def clone_value : T
       lock.synchronize { @value.clone }
     end
@@ -108,7 +108,7 @@ module Sync
     # outlives the lock, the value can be accessed concurrently to the
     # synchronized methods.
     #
-    # @[Experimental("The method may not have much value over #exclusive(&.itself)")]
+    # @[Experimental("The method may not have much value over #lock(&.itself)")]
     def get : T
       lock.synchronize { @value }
     end

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -53,7 +53,7 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def get(& : T -> U) : U forall U
+    def exclusive(& : T -> U) : U forall U
       lock.synchronize { yield @value }
     end
 

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -77,7 +77,7 @@ module Sync
     # the lock early, instead of keeping the lock acquired for a while,
     # preventing progress of other fibers.
     #
-    # @[Experimental("The method may not have much value over #get(&.dup)")]
+    # @[Experimental("The method may not have much value over #exclusive(&.dup)")]
     def dup_value : T
       lock.synchronize { @value.dup }
     end
@@ -85,7 +85,7 @@ module Sync
     # Locks the mutex and returns a deep copy of the value. The lock is
     # released before returning the new value.
     #
-    # @[Experimental("The method may not have much value over #get(&.clone)")]
+    # @[Experimental("The method may not have much value over #exclusive(&.clone)")]
     def clone_value : T
       lock.synchronize { @value.clone }
     end
@@ -103,8 +103,8 @@ module Sync
     # outlives the lock, the value can be accessed concurrently to the
     # synchronized methods.
     #
-    # @[Experimental("The method may not have much value over #get(&.itself)")]
-    def value : T
+    # @[Experimental("The method may not have much value over #exclusive(&.itself)")]
+    def get : T
       lock.synchronize { @value }
     end
 

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -113,6 +113,11 @@ module Sync
       lock.synchronize { @value }
     end
 
+    @[Deprecated("Use #get instead.")]
+    def value : T
+      get
+    end
+
     # Locks the mutex and sets the value. Unlocks the mutex before returning.
     #
     # Always acquires and releases the lock, so writing the value is always

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -57,7 +57,7 @@ module Sync
       lock.synchronize { yield @value }
     end
 
-    @[Deprecated("use #exclusive instead.")]
+    @[Deprecated("Use #exclusive instead.")]
     def get(& : T -> U) : U forall U
       exclusive { |value| yield value }
     end

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -15,11 +15,11 @@ module Sync
   #   @@running : Sync::Shared.new([] of Queue)
   #
   #   def self.on_started(queue)
-  #     @@running.exclusive(&.push(queue))
+  #     @@running.lock(&.push(queue))
   #   end
   #
   #   def self.on_stopped(queue)
-  #     @@running.exclusive(&.delete(queue))
+  #     @@running.lock(&.delete(queue))
   #   end
   #
   #   def self.each(&)
@@ -72,13 +72,13 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def exclusive(& : T -> U) : U forall U
+    def lock(& : T -> U) : U forall U
       lock.write { yield @value }
     end
 
-    @[Deprecated("Use #exclusive instead.")]
+    @[Deprecated("Use #lock instead.")]
     def write(& : T -> U) : U forall U
-      exclusive { |value| yield value }
+      lock { |value| yield value }
     end
 
     # Locks in exclusive mode, yields the current value and eventually replaces

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -133,6 +133,11 @@ module Sync
       lock.read { @value }
     end
 
+    @[Deprecated("Use #get instead.")]
+    def value : T
+      get
+    end
+
     # Locks in exclusive mode and sets the value.
     def set(value : T) : Nil
       lock.write { @value = value }

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -92,7 +92,7 @@ module Sync
     # help release the lock early, instead of keeping the lock acquired for a
     # while, preventing progress of fibers trying to lock exclusively.
     #
-    # @[Experimental("The method may not have much value over #read(&.dup)")]
+    # @[Experimental("The method may not have much value over #shared(&.dup)")]
     def dup_value : T
       lock.read { @value.dup }
     end
@@ -100,7 +100,7 @@ module Sync
     # Locks in shared mode and returns a deep copy of the value. The lock is
     # released before returning the new value.
     #
-    # @[Experimental("The method may not have much value over #read(&.clone)")]
+    # @[Experimental("The method may not have much value over #shared(&.clone)")]
     def clone_value : T
       lock.read { @value.clone }
     end
@@ -118,8 +118,8 @@ module Sync
     # outlives the lock, the value can be accessed concurrently to the
     # synchronized methods.
     #
-    # @[Experimental("The method may not have much value over #read(&.itself)")]
-    def value : T
+    # @[Experimental("The method may not have much value over #shared(&.itself)")]
+    def get : T
       lock.read { @value }
     end
 

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -15,15 +15,15 @@ module Sync
   #   @@running : Sync::Shared.new([] of Queue)
   #
   #   def self.on_started(queue)
-  #     @@running.write(&.push(queue))
+  #     @@running.exclusive(&.push(queue))
   #   end
   #
   #   def self.on_stopped(queue)
-  #     @@running.write(&.delete(queue))
+  #     @@running.exclusive(&.delete(queue))
   #   end
   #
   #   def self.each(&)
-  #     @@running.read do |list|
+  #     @@running.shared do |list|
   #       list.each { |queue| yield queue }
   #     end
   #   end

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -59,6 +59,11 @@ module Sync
       lock.read { yield @value }
     end
 
+    @[Deprecated("use #shared instead.")]
+    def read(& : T -> U) : U forall U
+      shared { |value| yield value }
+    end
+
     # Locks in exclusive mode and yields the value. The lock is released before
     # returning.
     #
@@ -69,6 +74,11 @@ module Sync
     # returned.
     def exclusive(& : T -> U) : U forall U
       lock.write { yield @value }
+    end
+
+    @[Deprecated("use #exclusive instead.")]
+    def write(& : T -> U) : U forall U
+      exclusive { |value| yield value }
     end
 
     # Locks in exclusive mode, yields the current value and eventually replaces

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -55,7 +55,7 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def read(& : T -> U) : U forall U
+    def shared(& : T -> U) : U forall U
       lock.read { yield @value }
     end
 
@@ -67,7 +67,7 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def write(& : T -> U) : U forall U
+    def exclusive(& : T -> U) : U forall U
       lock.write { yield @value }
     end
 

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -59,7 +59,7 @@ module Sync
       lock.read { yield @value }
     end
 
-    @[Deprecated("use #shared instead.")]
+    @[Deprecated("Use #shared instead.")]
     def read(& : T -> U) : U forall U
       shared { |value| yield value }
     end
@@ -76,7 +76,7 @@ module Sync
       lock.write { yield @value }
     end
 
-    @[Deprecated("use #exclusive instead.")]
+    @[Deprecated("Use #exclusive instead.")]
     def write(& : T -> U) : U forall U
       exclusive { |value| yield value }
     end

--- a/test/exclusive_test.cr
+++ b/test/exclusive_test.cr
@@ -2,10 +2,10 @@ require "./test_helper"
 require "../src/exclusive"
 
 describe Sync::Exclusive do
-  it "#get(&)" do
+  it "#exclusive(&)" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Exclusive.new(ary)
-    var.get { |val| assert_same ary, val }
+    var.exclusive { |val| assert_same ary, val }
   end
 
   it "#get" do
@@ -80,9 +80,9 @@ describe Sync::Exclusive do
     counter = Atomic(Int64).new(0)
 
     10.times do
-      spawn(name: "get") do
+      spawn(name: "exclusive-read") do
         100.times do
-          var.get do |value|
+          var.exclusive do |value|
             value.each { counter.add(1, :relaxed) }
           end
           Fiber.yield
@@ -91,9 +91,9 @@ describe Sync::Exclusive do
     end
 
     5.times do
-      wg.spawn(name: "get-mutates") do
+      wg.spawn(name: "exclusive-write") do
         100.times do
-          var.get do |value|
+          var.exclusive do |value|
             100.times { value << value.size }
           end
           Fiber.yield
@@ -161,7 +161,7 @@ describe Sync::Exclusive do
       contexts << Fiber::ExecutionContext::Isolated.new("get") do
         ready.wait
         while running
-          Foo.foo.get do |value|
+          Foo.foo.exclusive do |value|
             case value
             in Foo
               assert_equal Foo::INSTANCE.as(Void*).address, value.as(Void*).address

--- a/test/exclusive_test.cr
+++ b/test/exclusive_test.cr
@@ -2,10 +2,10 @@ require "./test_helper"
 require "../src/exclusive"
 
 describe Sync::Exclusive do
-  it "#exclusive(&)" do
+  it "#lock(&)" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Exclusive.new(ary)
-    var.exclusive { |val| assert_same ary, val }
+    var.lock { |val| assert_same ary, val }
   end
 
   it "#get" do
@@ -82,7 +82,7 @@ describe Sync::Exclusive do
     10.times do
       spawn(name: "exclusive-read") do
         100.times do
-          var.exclusive do |value|
+          var.lock do |value|
             value.each { counter.add(1, :relaxed) }
           end
           Fiber.yield
@@ -93,7 +93,7 @@ describe Sync::Exclusive do
     5.times do
       wg.spawn(name: "exclusive-write") do
         100.times do
-          var.exclusive do |value|
+          var.lock do |value|
             100.times { value << value.size }
           end
           Fiber.yield
@@ -161,7 +161,7 @@ describe Sync::Exclusive do
       contexts << Fiber::ExecutionContext::Isolated.new("get") do
         ready.wait
         while running
-          Foo.foo.exclusive do |value|
+          Foo.foo.lock do |value|
             case value
             in Foo
               assert_equal Foo::INSTANCE.as(Void*).address, value.as(Void*).address

--- a/test/exclusive_test.cr
+++ b/test/exclusive_test.cr
@@ -11,7 +11,7 @@ describe Sync::Exclusive do
   it "#get" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Exclusive.new(ary)
-    assert_same ary, var.value
+    assert_same ary, var.get
   end
 
   it "#set" do
@@ -20,7 +20,7 @@ describe Sync::Exclusive do
 
     var = Sync::Exclusive.new(ary1)
     var.set(ary2)
-    assert_same ary2, var.value
+    assert_same ary2, var.get
   end
 
   it "#replace" do
@@ -32,7 +32,7 @@ describe Sync::Exclusive do
       assert_same ary1, value
       ary2
     end
-    assert_same ary2, var.value
+    assert_same ary2, var.get
   end
 
   it "#dup_value" do

--- a/test/shared_test.cr
+++ b/test/shared_test.cr
@@ -19,7 +19,7 @@ describe Sync::Shared do
   it "#get" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Shared.new(ary)
-    assert_same ary, var.value
+    assert_same ary, var.get
   end
 
   it "#set" do
@@ -28,7 +28,7 @@ describe Sync::Shared do
 
     var = Sync::Shared.new(ary1)
     var.set(ary2)
-    assert_same ary2, var.value
+    assert_same ary2, var.get
   end
 
   it "#replace" do
@@ -40,7 +40,7 @@ describe Sync::Shared do
       assert_same ary1, value
       ary2
     end
-    assert_same ary2, var.value
+    assert_same ary2, var.get
   end
 
   it "#dup_value" do

--- a/test/shared_test.cr
+++ b/test/shared_test.cr
@@ -8,10 +8,10 @@ describe Sync::Shared do
     var.shared { |val| assert_same ary, val }
   end
 
-  it "#exclusive(&)" do
+  it "#lock(&)" do
     ary1 = [1, 2, 3, 4, 5]
     var = Sync::Shared.new(ary1)
-    var.exclusive { |val| val << 6 }
+    var.lock { |val| val << 6 }
     assert_same ary1, var.get
     assert_equal [1, 2, 3, 4, 5, 6], ary1
   end
@@ -101,7 +101,7 @@ describe Sync::Shared do
     5.times do
       wg.spawn(name: "exclusive-write") do
         100.times do
-          var.exclusive do |value|
+          var.lock do |value|
             100.times { value << value.size }
           end
           Fiber.yield


### PR DESCRIPTION
An attempt to harmonize the `#get(&)` of `Sync::Exclusive(T)` vs `#read(&)` and `#write(&)` of `Sync::Shared(T)`.

~~I'm reusing the `#exclusive` and `#shared` names. I feel they're explicit by themselves, and they're also the terms actually used in the methods' documentation. There could be alternatives, but I fail to find something good (borrow/own? immutable/mutable? borrow_immutable/own_mutable?).~~

The exclusive lock methods are now `#lock(&)` and the shared lock method is `#shared(&)`. See the discussion below for details.

Since the methods don't have anything to do with "get" in their name, I renamed the `#value` method back to `#get` for its parallelism with `#set` and the `#unsafe_get` / `#unsafe_set` pair.

Reference: https://github.com/ysbaddaden/sync/pull/13#issuecomment-2902480183