### PR TITLE
Harmonize naming Shared(T) and Exclusive(T) methods to own/borrow

### DIFF
--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -14,15 +14,15 @@ module Sync
   #   @@running : Sync::Exclusive.new([] of Queue)
   #
   #   def self.on_started(queue)
-  #     @@running.get(&.push(queue))
+  #     @@running.own(&.push(queue))
   #   end
   #
   #   def self.on_stopped(queue)
-  #     @@running.get(&.delete(queue))
+  #     @@running.own(&.delete(queue))
   #   end
   #
   #   def self.each(&)
-  #     @@running.get do |list|
+  #     @@running.own do |list|
   #       list.each { |queue| yield queue }
   #     end
   #   end
@@ -45,6 +45,11 @@ module Sync
       @lock.to_reference
     end
 
+    @[Deprecated("Use #own instead.")]
+    def get(& : T -> U) : U forall U
+      own { |value| yield value }
+    end
+
     # Locks the mutex and yields the value. The lock is released before
     # returning.
     #
@@ -53,7 +58,7 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def get(& : T -> U) : U forall U
+    def own(& : T -> U) : U forall U
       lock.synchronize { yield @value }
     end
 
@@ -77,7 +82,7 @@ module Sync
     # the lock early, instead of keeping the lock acquired for a while,
     # preventing progress of other fibers.
     #
-    # @[Experimental("The method may not have much value over #get(&.dup)")]
+    # @[Experimental("The method may not have much value over #own(&.dup)")]
     def dup_value : T
       lock.synchronize { @value.dup }
     end
@@ -85,7 +90,7 @@ module Sync
     # Locks the mutex and returns a deep copy of the value. The lock is
     # released before returning the new value.
     #
-    # @[Experimental("The method may not have much value over #get(&.clone)")]
+    # @[Experimental("The method may not have much value over #own(&.clone)")]
     def clone_value : T
       lock.synchronize { @value.clone }
     end
@@ -103,8 +108,8 @@ module Sync
     # outlives the lock, the value can be accessed concurrently to the
     # synchronized methods.
     #
-    # @[Experimental("The method may not have much value over #get(&.itself)")]
-    def value : T
+    # @[Experimental("The method may not have much value over #own(&.itself)")]
+    def get : T
       lock.synchronize { @value }
     end
 

--- a/test/exclusive_test.cr
+++ b/test/exclusive_test.cr
@@ -2,16 +2,16 @@ require "./test_helper"
 require "../src/exclusive"
 
 describe Sync::Exclusive do
-  it "#get(&)" do
+  it "#own(&)" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Exclusive.new(ary)
-    var.get { |val| assert_same ary, val }
+    var.own { |val| assert_same ary, val }
   end
 
   it "#get" do
     ary = [1, 2, 3, 4, 5]
     var = Sync::Exclusive.new(ary)
-    assert_same ary, var.value
+    assert_same ary, var.get
   end
 
   it "#set" do
@@ -20,7 +20,7 @@ describe Sync::Exclusive do
 
     var = Sync::Exclusive.new(ary1)
     var.set(ary2)
-    assert_same ary2, var.value
+    assert_same ary2, var.get
   end
 
   it "#replace" do
@@ -32,7 +32,7 @@ describe Sync::Exclusive do
       assert_same ary1, value
       ary2
     end
-    assert_same ary2, var.value
+    assert_same ary2, var.get
   end
 
   it "#dup_value" do
@@ -80,9 +80,9 @@ describe Sync::Exclusive do
     counter = Atomic(Int64).new(0)
 
     10.times do
-      spawn(name: "get") do
+      spawn(name: "exclusive-read") do
         100.times do
-          var.get do |value|
+          var.own do |value|
             value.each { counter.add(1, :relaxed) }
           end
           Fiber.yield
@@ -91,9 +91,9 @@ describe Sync::Exclusive do
     end
 
     5.times do
-      wg.spawn(name: "get-mutates") do
+      wg.spawn(name: "exclusive-write") do
         100.times do
-          var.get do |value|
+          var.own do |value|
             100.times { value << value.size }
           end
           Fiber.yield
@@ -161,7 +161,7 @@ describe Sync::Exclusive do
       contexts << Fiber::ExecutionContext::Isolated.new("get") do
         ready.wait
         while running
-          Foo.foo.get do |value|
+          Foo.foo.own do |value|
             case value
             in Foo
               assert_equal Foo::INSTANCE.as(Void*).address, value.as(Void*).address


### PR DESCRIPTION
I tried renaming the `#get(&)`, `#read(&)` and `#write(&)` methods to `#own(&)` and `#borrow(&)` but... I can't convince myself this is better than #14 :disappointed: 

The own/borrow pair of words is good, but when it comes to use the methods, the shared/exclusive choice of words is more explicit to me.