### PR TITLE
Fix: prohibit dup of primitives

### DIFF
--- a/src/condition_variable.cr
+++ b/src/condition_variable.cr
@@ -50,5 +50,10 @@ module Sync
     def broadcast : Nil
       @cv.broadcast
     end
+
+    # :nodoc:
+    def dup
+      {% raise "Can't dup {{@type}}" %}
+    end
   end
 end

--- a/src/exclusive.cr
+++ b/src/exclusive.cr
@@ -136,5 +136,10 @@ module Sync
     protected def wait(cv : Pointer(CV)) : Nil
       lock.wait(cv)
     end
+
+    # :nodoc:
+    def dup
+      {% raise "Can't dup {{@type}}" %}
+    end
   end
 end

--- a/src/future.cr
+++ b/src/future.cr
@@ -135,5 +135,10 @@ module Sync
         raise Error::Failed.new
       end
     end
+
+    # :nodoc:
+    def dup
+      {% raise "Can't dup {{@type}}" %}
+    end
   end
 end

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -95,5 +95,10 @@ module Sync
     protected def owns_lock? : Bool
       @locked_by == Fiber.current
     end
+
+    # :nodoc:
+    def dup
+      {% raise "Can't dup {{@type}}" %}
+    end
   end
 end

--- a/src/rw_lock.cr
+++ b/src/rw_lock.cr
@@ -147,5 +147,10 @@ module Sync
     protected def owns_lock? : Bool
       @locked_by == Fiber.current
     end
+
+    # :nodoc:
+    def dup
+      {% raise "Can't dup {{@type}}" %}
+    end
   end
 end

--- a/src/shared.cr
+++ b/src/shared.cr
@@ -148,5 +148,10 @@ module Sync
     protected def wait(cv : Pointer(CV)) : Nil
       lock.wait(cv)
     end
+
+    # :nodoc:
+    def dup
+      {% raise "Can't dup {{@type}}" %}
+    end
   end
 end


### PR DESCRIPTION
The default `Reference#dup` implementation would duplicate the object as-is, and for example keep it locked (oops), or keep a list of pending fibers (oops), or `Sync::ConditionVariable` would dup `@lockable`... that won't be accessible :shrug:

Fixes #15