### PR TITLE
Fix: segfaults and hangs in `Sync::CV`

### DIFF
--- a/src/cv.cr
+++ b/src/cv.cr
@@ -56,12 +56,12 @@ module Sync
       waiter.value.wait
       # ...resumed
 
-      if waiter.value.cv_mu
+      if cv_mu = waiter.value.cv_mu
         # waiter was woken from cv, and must re-acquire mu
         if waiter.value.writer?
-          mu.value.lock
+          cv_mu.value.lock
         else
-          mu.value.rlock
+          cv_mu.value.rlock
         end
       else
         # waiter was moved to mu's queue, then awoken from mu and is thus a

--- a/src/dll.cr
+++ b/src/dll.cr
@@ -20,8 +20,8 @@ module Sync
   struct Dll(T)
     module Node
       macro included
-        property next : ::Pointer(self) = Pointer(self).null
-        property prev : ::Pointer(self) = Pointer(self).null
+        property next : ::Pointer(self) = ::Pointer(self).null
+        property prev : ::Pointer(self) = ::Pointer(self).null
 
         macro init(*args)
           \%node = ::{{@type}}.new(\{{args.splat}})

--- a/test/condition_variable_test.cr
+++ b/test/condition_variable_test.cr
@@ -3,6 +3,19 @@ require "../src/mutex"
 require "../src/condition_variable"
 
 class Sync::ConditionVariableTest < Minitest::Test
+  def test_signal
+    m = Sync::Mutex.new
+    c = Sync::ConditionVariable.new(m)
+
+    m.synchronize do
+      spawn do
+        m.synchronize { c.signal }
+      end
+
+      c.wait
+    end
+  end
+
   def test_signal_mutex
     m = Sync::Mutex.new
     c = Sync::ConditionVariable.new(m)


### PR DESCRIPTION
While trying to port MU and CV for Thread (instead of Fiber) in Crystal stdlib, I realized that the `MU#try_transfer` was completely wrong, or was replacing a `MU` pointer with a NULL pointer in `CV#wait`, ... :facepalm: 